### PR TITLE
Wrapping ads text in html tag if not already present

### DIFF
--- a/src/com/adsdk/sdk/banner/BannerAdView.java
+++ b/src/com/adsdk/sdk/banner/BannerAdView.java
@@ -289,11 +289,19 @@ public class BannerAdView extends RelativeLayout {
 				String text = MessageFormat.format(Const.IMAGE_BODY, this.response.getImageUrl(), this.response.getBannerWidth(), this.response.getBannerHeight());
 				Log.d(Const.TAG, "set image: " + text);
 				text = Uri.encode(Const.HIDE_BORDER + text);
+				if (!text.contains("<html>")) {
+					text = "<html><head></head><body style='margin:0;padding:0;'>"
+							+ text + "</body></html>";
+				}
 				webView.loadData(text, "text/html", Const.ENCODING);
 				adListener.onLoad();
 			} else if (this.response.getType() == Const.TEXT) {
-				final String text = Uri.encode(Const.HIDE_BORDER + this.response.getText());
+				String text = Uri.encode(Const.HIDE_BORDER + this.response.getText());
 				Log.d(Const.TAG, "set text: " + text);
+				if (!text.contains("<html>")) {
+					text = "<html><head></head><body style='margin:0;padding:0;'>"
+							+ text + "</body></html>";
+				}
 				webView.loadData(text, "text/html", Const.ENCODING);
 				adListener.onLoad();
 			}


### PR DESCRIPTION
Fixes some ads not showing in 4.4 webview.

Probably newer Android Webview (since 4.4) is not that much happy to receive badly formed html