### PR TITLE
Removed weird unicode characters from proguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ In your project's ```AndroidManifest.xml``` under the ```manifest``` tag, add th
 
 ## Proguard
 ```proguard
--keep class com.mobfox.** { *; } 
--keep class com.mobfox.adapter.** {*;} 
+-keep class com.mobfox.** { *; }
+-keep class com.mobfox.adapter.** {*;}
 -keep class com.mobfox.sdk.** {*;}
 ```
 


### PR DESCRIPTION
Also, is this still up to date? I don't see a `com.mobfox.adapters` package. I see a `com.mobfox.sdk.adapters`, is that what this should be updated to?